### PR TITLE
Upgrade to .NET 10 and refactor Docker utilities for improved port ma…

### DIFF
--- a/DevOps/build.yml
+++ b/DevOps/build.yml
@@ -16,16 +16,6 @@ jobs:
         feedsToUse: 'config'
         nugetConfigPath: 'nuget.config'
 
-    - task: SonarCloudPrepare@1
-      inputs:
-        SonarCloud: 'SonarCloud'
-        organization: '$(sonarCloudOrganization)'
-        scannerMode: 'MSBuild'
-        projectKey: '$(sonarCloudProjectKey)'
-        projectName: '$(sonarCloudProjectName)'
-        extraProperties: |
-          sonar.cs.opencover.reportsPaths=$(Agent.TempDirectory)/**/coverage.opencover.xml
-
     - task: DotNetCoreCLI@2
       displayName: Build and Pack
       inputs:
@@ -56,12 +46,6 @@ jobs:
         summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
         reportDirectory: '$(Agent.TempDirectory)'
         failIfCoverageEmpty: false
-
-    - task: SonarCloudAnalyze@1      
-
-    - task: SonarCloudPublish@1      
-      inputs:
-        pollingTimeoutSec: '300'
 
     - publish: $(Build.ArtifactStagingDirectory)
       artifact: $(artifactName)

--- a/Southport.UnitTesting.EFCore.SQL.Tests/Southport.UnitTesting.EFCore.SQL.Tests.csproj
+++ b/Southport.UnitTesting.EFCore.SQL.Tests/Southport.UnitTesting.EFCore.SQL.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -9,17 +9,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Southport.UnitTesting.EFCore.SQL/DockerSqlDatabaseUtilities.cs
+++ b/Southport.UnitTesting.EFCore.SQL/DockerSqlDatabaseUtilities.cs
@@ -21,11 +21,19 @@ public static class DockerSqlDatabaseUtilities
 
     public static string DbName = "SQLUnitTests";
 
+    public static string ActivePortNumber;
+
     public static int ContainerExpirationHours = 24;
     public static int MaxSqlAvailabilityWaitSeconds = 120;
 
     public static async Task<string> EnsureDockerStartedAndGetContainerIdAndPortAsync(bool forceCleanup = false)
     {
+        if (!string.IsNullOrWhiteSpace(ActivePortNumber))
+        {
+            await CreateDatabaseIfDoesNotExist(ActivePortNumber);
+            return ActivePortNumber;
+        }
+        
         await CleanupRunningContainers(forceCleanup ? 0 : ContainerExpirationHours);
         await CleanupRunningVolumes(forceCleanup ? 0 : ContainerExpirationHours);
         var dockerClient = GetDockerClient();
@@ -46,10 +54,10 @@ public static class DockerSqlDatabaseUtilities
         await StartContainer(dockerClient, existingCont.ID);
 
         existingCont = await GetExistingContainer(dockerClient);
-        var databasePort = existingCont.Ports.First().PublicPort.ToString();
-        await WaitUntilDatabaseAvailableAsync(databasePort);
-        await CreateDatabaseIfDoesNotExist(databasePort);
-        return databasePort;
+        ActivePortNumber = existingCont.Ports.First().PublicPort.ToString();
+        await WaitUntilDatabaseAvailableAsync(ActivePortNumber);
+        await CreateDatabaseIfDoesNotExist(ActivePortNumber);
+        return ActivePortNumber;
     }
 
     private static async Task ManageVolumes(DockerClient dockerClient)

--- a/Southport.UnitTesting.EFCore.SQL/Southport.UnitTesting.EFCore.SQL.csproj
+++ b/Southport.UnitTesting.EFCore.SQL/Southport.UnitTesting.EFCore.SQL.csproj
@@ -1,50 +1,53 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
-	<IsPackable>true</IsPackable>
-	<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <Authors>Robert Anstett</Authors>
-    <Company>Southport Solutions, LLC</Company>
-    <Product>Southport.UnitTesting.EFCore.SQL</Product>
-    <Description>Southport Solutions EFCore SQL unit testing using docker.</Description>
-    <Copyright>© Southport Solutions, LLC. All rights reserved.</Copyright>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageIcon>icon.png</PackageIcon>
-    <RepositoryType>GIT</RepositoryType>
-    <PackageTags>Docker EntityFrameworkCore EntityFramework</PackageTags>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+        <IsPackable>true</IsPackable>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+        <Authors>Robert Anstett</Authors>
+        <Company>Southport Solutions, LLC</Company>
+        <Product>Southport.UnitTesting.EFCore.SQL</Product>
+        <Description>Southport Solutions EFCore SQL unit testing using docker.</Description>
+        <Copyright>© Southport Solutions, LLC. All rights reserved.</Copyright>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageIcon>icon.png</PackageIcon>
+        <RepositoryType>GIT</RepositoryType>
+        <PackageTags>Docker EntityFrameworkCore EntityFramework</PackageTags>
+    </PropertyGroup>
 
-  <ItemGroup>
-	  <None Include="..\icon.png">
-		  <Pack>True</Pack>
-		  <PackagePath></PackagePath>
-	  </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\icon.png">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+    </ItemGroup>
 
-  <ItemGroup>
-	<PackageReference Include="AutoBogus" Version="2.13.1" />
-	<PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
-    <PackageReference Include="Docker.DotNet" Version="3.125.15" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
-    <PackageReference Include="Respawn" Version="6.2.1" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="AutoBogus" Version="2.13.1"/>
+        <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1"/>
+        <PackageReference Include="Docker.DotNet" Version="3.125.15"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.3" Condition="'$(TargetFramework)' == 'net9.0'"/>
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.3" Condition="'$(TargetFramework)' == 'net10.0'"/>
+        <PackageReference Include="Respawn" Version="7.0.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="SouthportUnitTestBase.cs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Compile>
-    <Compile Update="UnitTestBase.cs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Compile>
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Update="SouthportUnitTestBase.cs">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Compile>
+    </ItemGroup>
 
 </Project>

--- a/Southport.UnitTesting.EFCore.SQL/UnitTestBase.cs
+++ b/Southport.UnitTesting.EFCore.SQL/UnitTestBase.cs
@@ -1,20 +1,12 @@
 ﻿using AutoBogus;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Respawn;
-using Respawn.Graph;
 using Xunit.Abstractions;
 
 namespace Southport.UnitTesting.EFCore.SQL;
-
-[Obsolete($"Use {nameof(SouthportUnitTestBase)}.")]
-public abstract class UnitTestBase<TDbContext> : SouthportUnitTestBase<TDbContext> where TDbContext : DbContext
-{
-    protected UnitTestBase(ITestOutputHelper testLogger) : base(testLogger)
-    {
-    }
-}
 
 public abstract class SouthportUnitTestBase<TDbContext> : SouthportUnitTestBase where TDbContext : DbContext
 {
@@ -36,7 +28,6 @@ public abstract class SouthportUnitTestBase<TDbContext> : SouthportUnitTestBase 
     protected SouthportUnitTestBase(ITestOutputHelper testLogger) : base(testLogger)
     {
     }
-
 
     protected override async Task InitializeTest()
     {
@@ -111,13 +102,14 @@ public abstract class SouthportUnitTestBase<TDbContext> : SouthportUnitTestBase 
             }
         }
 
-        Checkpoint = await Respawner.CreateAsync(ConnectionString, new RespawnerOptions()
+        await using (var connection = new SqlConnection(ConnectionString))
         {
-            TablesToIgnore = new Table[]
+            await connection.OpenAsync();
+            Checkpoint = await Respawner.CreateAsync(connection, new RespawnerOptions()
             {
-                "__EFMigrationsHistory"
-            }
-        });
+                TablesToIgnore = ["__EFMigrationsHistory"]
+            });
+        }
 
         IsInitialized = true;
         IsInitializing = false;
@@ -159,7 +151,8 @@ public abstract class SouthportUnitTestBase<TDbContext> : SouthportUnitTestBase 
 
     protected virtual async Task ResetState()
     {
-        await Checkpoint.ResetAsync(ConnectionString);
+        await using var connection = new SqlConnection(ConnectionString);
+        await Checkpoint.ResetAsync(connection);
     }
 
     protected virtual void InitializeDbContext()


### PR DESCRIPTION
## **User description**
This pull request updates the project to support .NET 9 and 10, upgrades key dependencies (notably Entity Framework Core and xUnit), and improves the Docker SQL test utilities for more reliable test database management. It also removes obsolete code and modernizes how database resets and respawning are handled.

**.NET and Dependency Upgrades:**

* Updated target frameworks in both `Southport.UnitTesting.EFCore.SQL` and `Southport.UnitTesting.EFCore.SQL.Tests` projects to `net9.0` and `net10.0`, removing support for `net8.0`. [[1]](diffhunk://#diff-3f5bc16ecc153b2ea20c64e5c76639b781a28dd2f8c76d7e954e39bf17de07b9L4-R4) [[2]](diffhunk://#diff-1140a4359fb0694bec74c301029f2829d744749e361a4dffd7d0cffff2f1a8dbL4-R26)
* Upgraded major dependencies to their latest versions for both frameworks, including `Microsoft.EntityFrameworkCore.SqlServer`, `Microsoft.Data.SqlClient`, `xunit`, and related libraries. Conditional references are now used to ensure the correct versions per target framework. [[1]](diffhunk://#diff-3f5bc16ecc153b2ea20c64e5c76639b781a28dd2f8c76d7e954e39bf17de07b9L31-L47) [[2]](diffhunk://#diff-1140a4359fb0694bec74c301029f2829d744749e361a4dffd7d0cffff2f1a8dbL4-R26)

**Test Utilities and Codebase Improvements:**

* Enhanced `DockerSqlDatabaseUtilities` to cache and reuse the active SQL port number, reducing redundant Docker operations and improving performance for repeated test runs. [[1]](diffhunk://#diff-6fafafeafcb13e5308a6a5440d83685da4b911a09171fa613bb3c483d16f3ba0R24-R36) [[2]](diffhunk://#diff-6fafafeafcb13e5308a6a5440d83685da4b911a09171fa613bb3c483d16f3ba0L49-R60)
* Modernized database reset logic in `SouthportUnitTestBase` to use an explicit `SqlConnection` for checkpoint creation and reset, aligning with best practices and updated Respawn APIs. [[1]](diffhunk://#diff-df93a3b4e1474f3efae9535c1c51ce74140f2cdbd80bd961270ab04cfc8adcedL114-R112) [[2]](diffhunk://#diff-df93a3b4e1474f3efae9535c1c51ce74140f2cdbd80bd961270ab04cfc8adcedL162-R155)

**Code Cleanup:**

* Removed the obsolete `UnitTestBase` class and related references, consolidating test base logic in `SouthportUnitTestBase`. [[1]](diffhunk://#diff-df93a3b4e1474f3efae9535c1c51ce74140f2cdbd80bd961270ab04cfc8adcedR2-L18) [[2]](diffhunk://#diff-df93a3b4e1474f3efae9535c1c51ce74140f2cdbd80bd961270ab04cfc8adcedL40)

These changes ensure compatibility with the latest .NET and EF Core versions, improve test reliability, and simplify maintenance going forward.


___

## **CodeAnt-AI Description**
Add .NET 9/10 support and reuse Docker SQL container to speed and stabilize tests

### What Changed
- Projects and test projects now target net9.0 and net10.0 (net8.0 removed), and package references were updated per target framework so builds use newer EF Core, SQL client, Respawn, xUnit and test SDK versions.
- Docker test utilities now cache and reuse the active SQL container port so existing containers are reused instead of recreated; when a port is known the code ensures the test database exists and skips container recreation.
- Test base initialization and resets now use an open SQL connection for Respawn operations, making database resets and migration setup operate via the connection-based API.
- Removed an obsolete UnitTestBase wrapper; tests should use SouthportUnitTestBase directly.

### Impact
`✅ Faster test startup when reusing Docker SQL container`
`✅ More reliable test database resets`
`✅ Builds for .NET 9 and .NET 10`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
