### PR TITLE
Add CI/CD workflow for build and deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,77 @@
+
+name: CI/CD
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'release@*' ]
+
+env:
+  BUILD_CONFIGURATION: Release
+  PROJECT_NAME: Southport.UnitTesting.EFCore.SQL
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.x'
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/release@* ]]; then
+            # tag is like refs/tags/release@1.2.3
+            VERSION="${GITHUB_REF#refs/tags/release@}"
+          else
+            VERSION="1.0.0-alpha1"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Restore
+        run: dotnet restore "**/${{ env.PROJECT_NAME }}.csproj" --configfile nuget.config
+
+      - name: Build & Pack
+        run: |
+          dotnet pack "**/${{ env.PROJECT_NAME }}.csproj" \
+            --output "${{ github.workspace }}/artifacts" \
+            --configuration "${{ env.BUILD_CONFIGURATION }}" \
+            /p:Version="${{ steps.version.outputs.version }}"
+
+      - name: Test (NET9)
+        run: dotnet test "**/*Tests.csproj" --framework net9 --configuration "${{ env.BUILD_CONFIGURATION }}" --collect:"XPlat Code Coverage"
+
+      - name: Test (NET10)
+        run: dotnet test "**/*Tests.csproj" --framework net10 --configuration "${{ env.BUILD_CONFIGURATION }}" --collect:"XPlat Code Coverage"
+
+      - name: Code Coverage Report
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: "**/coverage.cobertura.xml"
+          badge: true
+          fail_below_min: false
+          format: markdown
+          hide_branch_rate: false
+          hide_complexity: true
+          indicators: true
+          output: both
+          thresholds: '60 80'
+
+      - name: Publish to nuget.org (only on release tags)
+        if: startsWith(github.ref, 'refs/tags/release@')
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_ORG_API_KEY }}
+        run: |
+          SOURCE="https://api.nuget.org/v3/index.json"
+          shopt -s nullglob
+          for package in "${{ github.workspace }}/artifacts/"*.nupkg; do
+            [[ "$package" == *.symbols.nupkg ]] && continue
+            dotnet nuget push "$package" --source "$SOURCE" --api-key "$NUGET_API_KEY" --skip-duplicate
+          done


### PR DESCRIPTION
## **User description**
This pull request introduces a new GitHub Actions workflow for CI/CD automation, streamlining the build, test, code coverage, and deployment process for the project. The workflow is triggered on pushes to the `main` branch and on release tags.

### CI/CD Workflow Automation

* Added `.github/workflows/main.yml` to automate build, test, code coverage, and deployment steps using GitHub Actions.
* Configured workflow to trigger on pushes to `main` and tags matching `release@*`.
* Automated .NET setup, restore, build, pack, and multi-targeted test execution for both .NET 9 and .NET 10 frameworks.
* Integrated code coverage reporting and badge generation using `irongut/CodeCoverageSummary`.
* Added conditional publishing of NuGet packages to nuget.org when a release tag is pushed, using a secret API key.


___

## **CodeAnt-AI Description**
**Add GitHub Actions CI/CD to build, test, report coverage, and publish NuGet packages**

### What Changed
- New GitHub Actions workflow runs on pushes to main and on tags matching release@*; it restores, builds, and packs the project into an artifacts folder and sets package version from the release tag (defaults to 1.0.0-alpha1 for non-tags).
- Runs tests for .NET 9 and .NET 10 on each run and collects code coverage, producing a coverage report and a coverage badge.
- When a release tag is pushed, the workflow automatically publishes built NuGet packages to nuget.org, skipping symbol packages and duplicate uploads.

### Impact
`✅ Automated NuGet publishing on release tags`
`✅ Tests run for .NET 9 and .NET 10 on main pushes`
`✅ Visible code coverage badge and report`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
