### PR TITLE
Feature/GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,11 +122,6 @@ jobs:
       - name: Publish to nuget.org (only on release tags)
         if: startsWith(github.ref, 'refs/tags/release@')
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_ORG_API_KEY }}
-        run: |
-          SOURCE="https://api.nuget.org/v3/index.json"
-          shopt -s nullglob
-          for package in "${{ github.workspace }}/artifacts/"*.nupkg; do
-            [[ "$package" == *.symbols.nupkg ]] && continue
-            dotnet nuget push "$package" --source "$SOURCE" --api-key "$NUGET_API_KEY" --skip-duplicate
-          done
+          NUGET_API_KEY: ${{ secrets.NUGETPUSH }}
+          SOURCE: 'https://api.nuget.org/v3/index.json'
+        run: dotnet nuget push ${PROJECT_NAME}.${VERSION}.nupkg --source ${SOURCE} --api-key ${NUGET_API_KEY}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
       
       - name: Test (NET9) and collect coverage
         run: |
-          dotnet test ./tests/YourProject.Tests.csproj \
+          dotnet test **/${{ env.PROJECT_NAME }}.Tests.csproj \
             --framework net9 \
             --configuration Release \
             --collect:"XPlat Code Coverage" \
@@ -82,7 +82,7 @@ jobs:
 
       - name: Test (NET10) and collect coverage
         run: |
-          dotnet test ./tests/YourProject.Tests.csproj \
+          dotnet test **/${{ env.PROJECT_NAME }}.Tests.csproj \
             --framework net10 \
             --configuration Release \
             --collect:"XPlat Code Coverage" \


### PR DESCRIPTION
## **User description**
This pull request updates the CI workflow in `.github/workflows/main.yml` to improve flexibility and simplify the publishing process. The most important changes include making test and publish steps dynamically reference the project name and version, and streamlining the NuGet publishing logic.

**CI/CD Improvements**

* Test steps for both NET9 and NET10 now use `${{ env.PROJECT_NAME }}` to dynamically select the test project, making the workflow reusable for different projects. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L75-R75) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L85-R85)

**NuGet Publishing Simplification**

* The publish step now uses `${PROJECT_NAME}` and `${VERSION}` to directly specify the package to push, replaces the API key secret with `${{ secrets.NUGETPUSH }}`, and removes the loop over multiple packages in favor of a single push command, simplifying the workflow and reducing potential errors.


___

## **CodeAnt-AI Description**
**Run tests based on project name and push a single, specific NuGet package on release**

### What Changed
- Tests for both NET9 and NET10 now run against the test project chosen from the PROJECT_NAME environment variable, ensuring the CI runs the intended test project and collects coverage for each framework.
- The release publish step now pushes a single package named with PROJECT_NAME and VERSION to nuget.org using the NUGETPUSH secret and a configured source, replacing the previous loop over all artifacts and symbol-skipping logic.

### Impact
`✅ Fewer release publish failures`
`✅ Consistent test coverage collection across NET9 and NET10`
`✅ Predictable, single-package publishing on release`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
